### PR TITLE
Fix nasty logging unbounded buffer

### DIFF
--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -73,7 +73,7 @@ type bufReader struct {
 
 // NewBufReader returns a new bufReader.
 func NewBufReader(r io.Reader) io.ReadCloser {
-	timeout := rand.New(rndSrc).Intn(120) + 180
+	timeout := rand.New(rndSrc).Intn(15) + 30 // Cycle the drain between 30 and 45 seconds
 
 	reader := &bufReader{
 		buf:                  &bytes.Buffer{},

--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -68,7 +68,7 @@ type bufReader struct {
 	resetTimeout         time.Duration
 	bufLenResetThreshold int64
 	maxReadDataReset     int64
-	maxRetainedBytes     int64
+	maxRetainedBytes     int
 }
 
 // NewBufReader returns a new bufReader.

--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -84,7 +84,7 @@ func NewBufReader(r io.Reader) io.ReadCloser {
 		resetTimeout:         time.Duration(timeout) * time.Second,
 		bufLenResetThreshold: 100 * 1024,
 		maxReadDataReset:     10 * 1024 * 1024,
-		maxRetainedBytes:     8192, // Max we'll retain when truncating on overflow
+		maxRetainedBytes:     1024 * 1024, // Max we'll retain when truncating on overflow (1MB)
 		reader:               r,
 	}
 	reader.wait.L = &reader.Mutex

--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/random"
 )
 
@@ -179,8 +180,11 @@ func (r *bufReader) drain() {
 				newbuf := &bytes.Buffer{}
 
 				if r.buf.Len() > r.maxRetainedBytes {
+					discardLength := r.buf.Len() - r.maxRetainedBytes
+
 					// Throw away all but the max we'll retain
-					r.buf.Next(r.buf.Len() - r.maxRetainedBytes)
+					log.Infof("Oversized pending log buffer, discarding %d bytes", discardLength)
+					r.buf.Next(discardLength)
 				}
 
 				// Read in anything left


### PR DESCRIPTION
When anything fails to read from the buffer, it will back up. When the drain cycles, it will create a new buffer but not actually remove any data. So if the logging rate continues to be higher than the flush rate, the buffer will grow unbounded.

This addresses that by taking the approach of throwing away more than `maxRetainedBytes` number of bytes at each drain cycle. Additionally, the drain cycle is ratcheted down substantially so that the buffer is cycled more often and the buffer truncated in the face of massive logging overruns.

cc @didip @dselans @intjonathan 
